### PR TITLE
Easy_deps: add support for dart projects

### DIFF
--- a/.mason/bricks.json
+++ b/.mason/bricks.json
@@ -1,1 +1,1 @@
-{"easy_deps":"/Users/badrkouki/Documents/Perso/mason-bricks/easy_deps","localiz":"/Users/badrkouki/Documents/Perso/mason-bricks/localiz"}
+{"localiz":"/Users/badrkouki/Documents/Perso/mason-bricks/localiz"}

--- a/easy_deps/__brick__/hooks/dependency_handler/package_installation_handler.dart
+++ b/easy_deps/__brick__/hooks/dependency_handler/package_installation_handler.dart
@@ -36,13 +36,13 @@ Future<void> installPackages(HookContext hookContext) async {
       installationCommandArgs.addAll(['--sdk', 'flutter']);
     }
     installationResult = await Process.run(
-      'flutter',
+      "{{project_type.lowerCase()}}",
       [...installationCommandArgs, '--offline'],
     );
 
     if (installationResult.exitCode != 0) {
       installationResult = await Process.run(
-        'flutter',
+        "{{project_type.lowerCase()}}",
         installationCommandArgs,
       );
     }

--- a/easy_deps/brick.yaml
+++ b/easy_deps/brick.yaml
@@ -1,6 +1,15 @@
 name: easy_deps
 description: Add packages installation to your mason brick project
 repository: https://github.com/koukibadr/mason-bricks
-version: 0.3.1+1
+version: 0.4.0+1
 environment:
   mason: ">=0.1.0-dev.51 <0.1.0"
+vars:
+  project_type:
+    type: enum
+    default: Flutter
+    values:
+      - Flutter
+      - Dart
+    prompt: Integrating brick for Flutter or Dart project ?
+    description: The target project sdk type (Flutter or native Dart)

--- a/mason-lock.json
+++ b/mason-lock.json
@@ -1,1 +1,1 @@
-{"bricks":{"easy_deps":{"path":"/Users/badrkouki/Documents/Perso/mason-bricks/easy_deps"},"localiz":{"path":"/Users/badrkouki/Documents/Perso/mason-bricks/localiz"}}}
+{"bricks":{"localiz":{"path":"/Users/badrkouki/Documents/Perso/mason-bricks/localiz"}}}

--- a/mason.yaml
+++ b/mason.yaml
@@ -1,8 +1,3 @@
-# Register bricks which can be consumed via the Mason CLI.
-# Run "mason get" to install all registered bricks.
-# To learn more, visit https://docs.brickhub.dev.
 bricks:
   localiz:
     path: ./localiz/
-  easy_deps:
-    path: ./easy_deps/


### PR DESCRIPTION
**Changes**
- Add support for native dart projects
- Add brick paramter "project_type" to define project's sdk (Flutter/Dart)